### PR TITLE
convert int to string before appending

### DIFF
--- a/src/PineconeStdLib.cpp
+++ b/src/PineconeStdLib.cpp
@@ -1488,7 +1488,7 @@ void populateStringFuncs()
 			int val=*((int*)leftIn);
 			if (val<0 || val>=256)
 			{
-				throw PineconeError("tried to make ascii string out of value "+val, RUNTIME_ERROR);
+				throw PineconeError("tried to make ascii string out of value "+to_string(val), RUNTIME_ERROR);
 			}
 			string out;
 			out+=(char)val;


### PR DESCRIPTION
> in creation of error message for implicit conversion of uint8 to string

It would seem that the developer has fallen prey to an error not entirely dissimilar to that of which the user is accused… 😋